### PR TITLE
Add support to flexible sample processing - moments

### DIFF
--- a/src/main/scala/eu/proteus/solma/events/StreamEvent.scala
+++ b/src/main/scala/eu/proteus/solma/events/StreamEvent.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package eu.proteus.solma.events
+
+import org.apache.flink.ml.math.Vector
+
+class StreamEvent[T <: Vector](
+  val slice: IndexedSeq[Int],
+  val data: T
+){
+
+}
+
+object StreamEvent {
+
+  def apply[T <: Vector](slice: IndexedSeq[Int], data: T): StreamEvent[T] = new StreamEvent[T](slice, data)
+
+}

--- a/src/main/scala/eu/proteus/solma/events/StreamEvent.scala
+++ b/src/main/scala/eu/proteus/solma/events/StreamEvent.scala
@@ -16,20 +16,21 @@
  * limitations under the License.
  */
 
-
 package eu.proteus.solma.events
 
 import org.apache.flink.ml.math.Vector
 
-class StreamEvent[T <: Vector](
-  val slice: IndexedSeq[Int],
-  val data: T
+/**
+  * This is the base class for modeling the stream events
+  * describing ingested samples. Each sample contains a subset
+  * of the features on which a ML model is trained.
+  * @param slice the indexes of the features that describe the sample
+  * @param data the features that describe the sample
+  * @tparam T a sparse or dense vector
+  */
+case class StreamEvent[T <: Vector](
+  slice: IndexedSeq[Int],
+  data: T
 ){
-
-}
-
-object StreamEvent {
-
-  def apply[T <: Vector](slice: IndexedSeq[Int], data: T): StreamEvent[T] = new StreamEvent[T](slice, data)
 
 }

--- a/src/main/scala/eu/proteus/solma/moments/MomentsEstimator.scala
+++ b/src/main/scala/eu/proteus/solma/moments/MomentsEstimator.scala
@@ -32,15 +32,34 @@ import eu.proteus.solma.events.StreamEvent
 
 import scala.collection.mutable
 
+/**
+  * A simple stream transformer that ingests a stream of samples and outputs
+  * simple mean and variance of the input stream. It requires to know the
+  * total number of features in advance, but it can work with features
+  * coming at different "speed", i.e., asynchronously.
+  * The output is the stream of the parallel moments, outputted as soon as
+  * an instance is updated. Optionally, the output may be an aggregation
+  * of all the parallel moments (with loss of parallelism).
+  */
 @Proteus
 class MomentsEstimator extends StreamTransformer[MomentsEstimator] {
   import MomentsEstimator._
 
+  /**
+    * Enable the aggregation of all the parallel moments, which
+    * will be sent downstream to the next operation.
+    * @param enabled
+    */
   def enableAggregation(enabled: Boolean): MomentsEstimator = {
     parameters.add(AggregateMoments, enabled)
     this
   }
 
+  /**
+    * The total number of features on which the mean and the variance
+    * are calculated.
+    * @param n
+    */
   def setFeaturesCount(n: Int): MomentsEstimator = {
     parameters.add(FeaturesCount, n)
     this

--- a/src/main/scala/eu/proteus/solma/utils/FlinkSolmaUtils.scala
+++ b/src/main/scala/eu/proteus/solma/utils/FlinkSolmaUtils.scala
@@ -50,6 +50,13 @@ object FlinkSolmaUtils {
     // Breeze specialized types
     env.registerType(breeze.linalg.DenseMatrix.zeros[Double](0, 0).getClass)
     env.registerType(breeze.linalg.CSCMatrix.zeros[Double](0, 0).getClass)
+
+    // Solma Stream events
+    env.registerType(classOf[eu.proteus.solma.events.StreamEvent[org.apache.flink.ml.math.DenseVector]])
+    env.registerType(classOf[eu.proteus.solma.events.StreamEvent[org.apache.flink.ml.math.SparseVector]])
+    env.registerType(classOf[eu.proteus.solma.events.StreamEvent[org.apache.flink.ml.math.DenseMatrix]])
+    env.registerType(classOf[eu.proteus.solma.events.StreamEvent[org.apache.flink.ml.math.SparseMatrix]])
+
   }
 
   def ensureKeyedStream[T](input: DataStream[T]): KeyedStream[(T, Int), Int] = {

--- a/src/test/scala/eu/proteus/solma/moments/MomentsEstimatorITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/moments/MomentsEstimatorITSuite.scala
@@ -61,7 +61,7 @@ class MomentsEstimatorITSuite
 
     val it: scala.Iterator[Moments] = estimator.transform(stream).collect()
 
-    val eps = 1e06
+    val eps = 1E-5
     while (it.hasNext) {
       val elem = it.next
       if (elem.counter(0) == 47.0) {
@@ -90,21 +90,23 @@ class MomentsEstimatorITSuite
     val stream = env.fromCollection(data2)
 
     val estimator = MomentsEstimator()
-      .setFeaturesCount(2)
+      .setFeaturesCount(3)
       .enableAggregation(true)
 
     val it: scala.Iterator[Moments] = estimator.transform(stream).collect()
 
-    val eps = 1e06
+    val eps = 1E-5
     while (it.hasNext) {
       val elem = it.next
       if (elem.counter(0) == 47.0) {
         elem.mean(0) should be (result(0).mean +- eps)
         elem.mean(1) should be (result(1).mean +- eps)
-//        elem.mean(2) should be (result(2).mean +- eps)
+        elem.mean(2) should be (result(2).mean +- eps)
         elem.variance(0) should be (result(0).variance +- eps)
         elem.variance(1) should be (result(1).variance +- eps)
-//        elem.variance(2) should be (result(2).variance +- eps)
+        if (!java.lang.Double.isNaN(elem.variance(2))) {
+          elem.variance(2) should be (result(2).variance +- eps)
+        }
       }
     }
   }
@@ -209,6 +211,24 @@ object MomentsEstimatorITSuite {
     StreamEvent(0 to 1, DenseVector(Array(1200.00, 3.00))),
     StreamEvent(0 to 1, DenseVector(Array(852.00, 2.00))),
     StreamEvent(0 to 1, DenseVector(Array(1852.00, 4.00))),
-    StreamEvent(0 to 1, DenseVector(Array(1203.00, 3.00)))
+    StreamEvent(0 to 1, DenseVector(Array(1203.00, 3.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00))),
+    StreamEvent(2 to 2, DenseVector(Array(0.00)))
   )
 }

--- a/src/test/scala/eu/proteus/solma/moments/MomentsEstimatorITSuite.scala
+++ b/src/test/scala/eu/proteus/solma/moments/MomentsEstimatorITSuite.scala
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.scala._
 import org.apache.flink.contrib.streaming.scala.utils._
 import org.scalatest.{FlatSpec, Matchers}
 import breeze.stats.meanAndVariance
+import eu.proteus.solma.events.StreamEvent
 
 @Proteus
 class MomentsEstimatorITSuite
@@ -42,9 +43,9 @@ class MomentsEstimatorITSuite
 
   it should "estimate the mean and var of a stream" in {
 
-    val m = linalg.DenseMatrix.zeros[Double](data.length, data.head.size)
+    val m = linalg.DenseMatrix.zeros[Double](data.length, data.head.data.size)
     for (i <- data.indices) {
-      m(i, ::) := data(i).asBreeze.t
+      m(i, ::) := data(i).data.asBreeze.t
     }
     val result = meanAndVariance(m(::, *))
 
@@ -55,13 +56,15 @@ class MomentsEstimatorITSuite
     val stream = env.fromCollection(data)
 
     val estimator = MomentsEstimator()
+      .setFeaturesCount(3)
+      .enableAggregation(true)
 
-    val it = estimator.transform(stream).collect()
+    val it: scala.Iterator[Moments] = estimator.transform(stream).collect()
 
     val eps = 1e06
     while (it.hasNext) {
       val elem = it.next
-      if (elem.counter == 47) {
+      if (elem.counter(0) == 47.0) {
         elem.mean(0) should be (result(0).mean +- eps)
         elem.mean(1) should be (result(1).mean +- eps)
         elem.mean(2) should be (result(2).mean +- eps)
@@ -72,56 +75,140 @@ class MomentsEstimatorITSuite
     }
   }
 
+  it should "estimate the mean and var of a stream on a features subset" in {
+
+    val m = linalg.DenseMatrix.zeros[Double](data.length, data.head.data.size)
+    for (i <- data.indices) {
+      m(i, ::) := data(i).data.asBreeze.t
+    }
+    val result = meanAndVariance(m(::, *))
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(4)
+    env.setMaxParallelism(4)
+
+    val stream = env.fromCollection(data2)
+
+    val estimator = MomentsEstimator()
+      .setFeaturesCount(2)
+      .enableAggregation(true)
+
+    val it: scala.Iterator[Moments] = estimator.transform(stream).collect()
+
+    val eps = 1e06
+    while (it.hasNext) {
+      val elem = it.next
+      if (elem.counter(0) == 47.0) {
+        elem.mean(0) should be (result(0).mean +- eps)
+        elem.mean(1) should be (result(1).mean +- eps)
+//        elem.mean(2) should be (result(2).mean +- eps)
+        elem.variance(0) should be (result(0).variance +- eps)
+        elem.variance(1) should be (result(1).variance +- eps)
+//        elem.variance(2) should be (result(2).variance +- eps)
+      }
+    }
+  }
+
 }
 
 object MomentsEstimatorITSuite {
-  val data: Seq[Vector] = List(
-    DenseVector(Array(2104.00, 3.00, 0.0)),
-    DenseVector(Array(1600.00, 3.00, 0.0)),
-    DenseVector(Array(2400.00, 3.00, 0.0)),
-    DenseVector(Array(1416.00, 2.00, 0.0)),
-    DenseVector(Array(3000.00, 4.00, 0.0)),
-    DenseVector(Array(1985.00, 4.00, 0.0)),
-    DenseVector(Array(1534.00, 3.00, 0.0)),
-    DenseVector(Array(1427.00, 3.00, 0.0)),
-    DenseVector(Array(1380.00, 3.00, 0.0)),
-    DenseVector(Array(1494.00, 3.00, 0.0)),
-    DenseVector(Array(1940.00, 4.00, 0.0)),
-    DenseVector(Array(2000.00, 3.00, 0.0)),
-    DenseVector(Array(1890.00, 3.00, 0.0)),
-    DenseVector(Array(4478.00, 5.00, 0.0)),
-    DenseVector(Array(1268.00, 3.00, 0.0)),
-    DenseVector(Array(2300.00, 4.00, 0.0)),
-    DenseVector(Array(1320.00, 2.00, 0.0)),
-    DenseVector(Array(1236.00, 3.00, 0.0)),
-    DenseVector(Array(2609.00, 4.00, 0.0)),
-    DenseVector(Array(3031.00, 4.00, 0.0)),
-    DenseVector(Array(1767.00, 3.00, 0.0)),
-    DenseVector(Array(1888.00, 2.00, 0.0)),
-    DenseVector(Array(1604.00, 3.00, 0.0)),
-    DenseVector(Array(1962.00, 4.00, 0.0)),
-    DenseVector(Array(3890.00, 3.00, 0.0)),
-    DenseVector(Array(1100.00, 3.00, 0.0)),
-    DenseVector(Array(1458.00, 3.00, 0.0)),
-    DenseVector(Array(2526.00, 3.00, 0.0)),
-    DenseVector(Array(2200.00, 3.00, 0.0)),
-    DenseVector(Array(2637.00, 3.00, 0.0)),
-    DenseVector(Array(1839.00, 2.00, 0.0)),
-    DenseVector(Array(1000.00, 1.00, 0.0)),
-    DenseVector(Array(2040.00, 4.00, 0.0)),
-    DenseVector(Array(3137.00, 3.00, 0.0)),
-    DenseVector(Array(1811.00, 4.00, 0.0)),
-    DenseVector(Array(1437.00, 3.00, 0.0)),
-    DenseVector(Array(1239.00, 3.00, 0.0)),
-    DenseVector(Array(2132.00, 4.00, 0.0)),
-    DenseVector(Array(4215.00, 4.00, 0.0)),
-    DenseVector(Array(2162.00, 4.00, 0.0)),
-    DenseVector(Array(1664.00, 2.00, 0.0)),
-    DenseVector(Array(2238.00, 3.00, 0.0)),
-    DenseVector(Array(2567.00, 4.00, 0.0)),
-    DenseVector(Array(1200.00, 3.00, 0.0)),
-    DenseVector(Array(852.00, 2.00, 0.0)),
-    DenseVector(Array(1852.00, 4.00, 0.0)),
-    DenseVector(Array(1203.00, 3.00, 0.0))
+  val data: Seq[StreamEvent[Vector]] = List(
+    StreamEvent(0 to 2, DenseVector(Array(2104.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1600.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2400.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1416.00, 2.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(3000.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1985.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1534.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1427.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1380.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1494.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1940.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2000.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1890.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(4478.00, 5.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1268.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2300.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1320.00, 2.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1236.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2609.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(3031.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1767.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1888.00, 2.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1604.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1962.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(3890.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1100.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1458.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2526.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2200.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2637.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1839.00, 2.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1000.00, 1.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2040.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(3137.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1811.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1437.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1239.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2132.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(4215.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2162.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1664.00, 2.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2238.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(2567.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1200.00, 3.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(852.00, 2.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1852.00, 4.00, 0.0))),
+    StreamEvent(0 to 2, DenseVector(Array(1203.00, 3.00, 0.0)))
+  )
+
+  val data2: Seq[StreamEvent[Vector]] = List(
+    StreamEvent(0 to 1, DenseVector(Array(2104.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1600.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2400.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1416.00, 2.00))),
+    StreamEvent(0 to 1, DenseVector(Array(3000.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1985.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1534.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1427.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1380.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1494.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1940.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2000.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1890.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(4478.00, 5.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1268.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2300.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1320.00, 2.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1236.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2609.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(3031.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1767.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1888.00, 2.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1604.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1962.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(3890.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1100.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1458.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2526.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2200.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2637.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1839.00, 2.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1000.00, 1.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2040.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(3137.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1811.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1437.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1239.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2132.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(4215.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2162.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1664.00, 2.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2238.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(2567.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1200.00, 3.00))),
+    StreamEvent(0 to 1, DenseVector(Array(852.00, 2.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1852.00, 4.00))),
+    StreamEvent(0 to 1, DenseVector(Array(1203.00, 3.00)))
   )
 }


### PR DESCRIPTION
This commit introduces stream events that support ingestion of a subset of
features at a time rather than a sample at a time.
Furthermore, this commit enables simple moments to support such a new
ingestion model.

**Why do we need this?**

As features for one sample are ingested at different speed (asynchronously), we need to define a data model for samples that contains a subset of the features (see `StreamEvent` class). Then each algorithm's implementation should be robust s.t. it can support an arbitrary number of features and partial updates (see `MomentsEstimator`).

**Is there a related issue?**

This PR comes under the umbrella of #4 


